### PR TITLE
Update http-parser submodule location and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+webserver

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/joyent/libuv.git
 [submodule "http-parser"]
 	path = http-parser
-	url = http://github.com/joyent/http-parser.git
+	url = https://github.com/joyent/http-parser.git


### PR DESCRIPTION
Github doesn't serve repos with http anymore so `git clone --recursive` fails. Changing the location of `joyent/http-parser` makes it works.
