### PR TITLE
Performance and fixes

### DIFF
--- a/webserver.c
+++ b/webserver.c
@@ -12,9 +12,18 @@
     exit(1); \
   }
 #define UVERR(err, msg) fprintf(stderr, "%s: %s\n", msg, uv_strerror(err))
+
+//#define LOGGING 1
+
+#ifdef LOGGING
 #define LOG(msg) puts(msg);
 #define LOGF(fmt, params...) printf(fmt "\n", params);
 #define LOG_ERROR(msg) puts(msg);
+#else
+#define LOG(msg) do { } while (0);
+#define LOGF(fmt, params...) do { } while (0);
+#define LOG_ERROR(msg) do { } while (0);
+#endif
 
 #define RESPONSE \
   "HTTP/1.1 200 OK\r\n" \

--- a/webserver.c
+++ b/webserver.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 #include "libuv/include/uv.h"
 #include "http-parser/http_parser.h"
@@ -125,7 +126,7 @@ int main() {
   parser_settings.on_headers_complete = on_headers_complete;
   
   resbuf.base = RESPONSE;
-  resbuf.len = sizeof(RESPONSE);
+  resbuf.len = strlen(RESPONSE);
 
   uv_loop = uv_default_loop();
 


### PR DESCRIPTION
Fix HTTP response corruption and disable logging to speed up the libuv-webserver from 40K to 90K.
